### PR TITLE
Replace Ping functionality with RTT from TCP & export data in CSV via settings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -184,6 +184,7 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.70'
     implementation 'org.apache.commons:commons-csv:1.9.0'
     implementation 'io.github.azhon:appupdate:4.3.2'
+    implementation 'androidx.documentfile:documentfile:1.0.1'
 
     // Analytics
     implementation "com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
             android:grantUriPermissions="true">
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/filepaths" />
+                android:resource="@xml/file_paths" />
         </provider>
 
         <provider

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <permission-group android:name="${applicationId}.andpermission"/>
     <queries>

--- a/app/src/main/java/com/lcl/lclmeasurementtool/MainActivity2.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/MainActivity2.kt
@@ -55,7 +55,7 @@ class MainActivity2 : ComponentActivity() {
 
         if (!hasPermission()) {
             XXPermissions.with(this)
-                .permission(Permission.CAMERA, Permission.READ_EXTERNAL_STORAGE, Permission.ACCESS_FINE_LOCATION)
+                .permission(Permission.CAMERA, Permission.READ_MEDIA_AUDIO, Permission.READ_MEDIA_VIDEO, Permission.READ_MEDIA_IMAGES, Permission.ACCESS_FINE_LOCATION)
                 .request { _, allGranted ->
                     run {
                         if (!allGranted) {

--- a/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
@@ -252,49 +252,31 @@ class MainActivityViewModel @Inject constructor(
 
     private suspend fun runMLabPing() {
         try {
-            MLabRunner.runTest(NDTTest.TestType.DOWNLOAD_AND_UPLOAD)
+            Ping.cancellableStart(address = NetworkConstants.PING_TEST_ADDRESS, timeout = 1000)
                 .onStart {
-                    Log.d(TAG, "TCP RTT check started")
+                    Log.d(TAG, "isActive = true")
                     _isMLabTestActive.value = true
                 }
                 .onCompletion {
                     if (it != null) {
-                        Log.d(TAG, "Error during RTT check: ${it.message}")
-                    }
-                    _isMLabTestActive.value = false
-                }
-                .collect { result ->
-                    // Extract RTT (µs → ms)
-                    val rttMicros = result.tcpInfo?.minRTT ?: 0L
-                    val rttMs = rttMicros / 1000.0
-
-                    Log.d(TAG, "Observed TCP MinRTT = $rttMs ms")
-
-                    // Update your PingResultState
-                    if (rttMs > 0) {
-                        _mLabPingResult.value = PingResultState.Success(
-                            PingResult(
-                                avg = rttMs.toString(),
-                                min = null,
-                                max = null,
-                                mdev = null,
-                                numLoss = "0",  // TCP doesn’t report loss
-                                error = PingError(PingErrorCase.OK, null)
-                            )
-                        )
-                    } else {
-                        _mLabPingResult.value = PingResultState.Error(
-                            PingError(PingErrorCase.OTHER, "No RTT data available")
-                        )
+                        Log.d(TAG, "Error is ${it.message}")
+                        _isMLabTestActive.value = false
                     }
                 }
-        } catch (e: Exception) {
-            _mLabPingResult.value =
-                PingResultState.Error(PingError(PingErrorCase.OTHER, e.message))
-            Log.e(TAG, "TCP RTT error: $e")
+                .collect {
+                    _mLabPingResult.value = when(it.error.code) {
+                        PingErrorCase.OK ->  PingResultState.Success(it)
+                        else ->  {
+                            _isMLabTestActive.value = false
+                            PingResultState.Error(it.error)
+                        }
+                    }
+                }
+        } catch (e: IllegalArgumentException) {
+            _mLabPingResult.value = PingResultState.Error(PingError(PingErrorCase.OTHER, e.message))
+            Log.e(TAG, "Ping Config error")
         }
     }
-
 
     fun cancelMLabTest() {
         Log.d(TAG, "cancellation: the test job is $mlabTestJob")

--- a/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
@@ -20,6 +20,7 @@ import com.lcl.lclmeasurementtool.telephony.SignalStrengthMonitor
 import com.lcl.lclmeasurementtool.util.*
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
@@ -29,6 +30,7 @@ import net.measurementlab.ndt7.android.NDTTest
 import okhttp3.ResponseBody
 import retrofit2.HttpException
 import java.io.ByteArrayOutputStream
+import java.net.InetAddress
 import java.security.SecureRandom
 import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
@@ -270,9 +272,12 @@ class MainActivityViewModel @Inject constructor(
                     when(it.type) {
                         NDTTest.TestType.UPLOAD -> {
                             // Extract RTT from TCPInfo if available during upload test
-                            it.tcpInfo?.rtt?.let { rtt ->
-                                _mlabRttResult.value = rtt.toDouble() / 1000.0 // Convert from microseconds to milliseconds
+                            if (it.tcpInfo?.rtt != null) {
+                                _mlabRttResult.value = it.tcpInfo.rtt.toDouble() / 1000.0 // Convert from microseconds to milliseconds
                                 Log.d(TAG, "RTT from Upload test: ${_mlabRttResult.value} ms")
+                            } else {
+                                // Fallback to a default RTT measurement
+                                estimateRttFromSpeedTest()
                             }
                             
                             _mLabUploadResult.value = when(it.status) {
@@ -288,9 +293,12 @@ class MainActivityViewModel @Inject constructor(
                         }
                         NDTTest.TestType.DOWNLOAD -> {
                             // Extract RTT from TCPInfo if available during download test
-                            it.tcpInfo?.rtt?.let { rtt ->
-                                _mlabRttResult.value = rtt.toDouble() / 1000.0 // Convert from microseconds to milliseconds
+                            if (it.tcpInfo?.rtt != null) {
+                                _mlabRttResult.value = it.tcpInfo.rtt.toDouble() / 1000.0 // Convert from microseconds to milliseconds
                                 Log.d(TAG, "RTT from Download test: ${_mlabRttResult.value} ms")
+                            } else {
+                                // Fallback to a default RTT measurement 
+                                estimateRttFromSpeedTest()
                             }
                             
                             _mLabDownloadResult.value = when(it.status) {
@@ -425,6 +433,32 @@ class MainActivityViewModel @Inject constructor(
         _mlabRttResult.value = 0.0
         _mLabUploadResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
         _mLabDownloadResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
+    }
+    
+    /**
+     * Estimates RTT using a ping to Google's DNS server as a fallback
+     * This is used when TCPInfo is not available from the ndt7 library
+     */
+    private fun estimateRttFromSpeedTest() {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                // Simple RTT calculation using java's InetAddress.isReachable
+                val start = System.currentTimeMillis()
+                val isReachable = InetAddress.getByName("8.8.8.8").isReachable(5000)
+                val rtt = System.currentTimeMillis() - start
+                
+                if (isReachable) {
+                    _mlabRttResult.value = rtt.toDouble()
+                    Log.d(TAG, "Fallback RTT measurement: ${_mlabRttResult.value} ms")
+                } else {
+                    Log.d(TAG, "Fallback RTT measurement failed")
+                    _mlabRttResult.value = 100.0 // Default value if measurement fails
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error in fallback RTT measurement", e)
+                _mlabRttResult.value = 100.0 // Default value if measurement fails
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
@@ -64,7 +64,7 @@ class MainActivityViewModel @Inject constructor(
     // Network Testing
     private val _isMLabTestActive = MutableStateFlow(false)
 
-    private var _mlabRttResult = MutableStateFlow(0.0)
+    private var _mlabRttResult = MutableStateFlow(ConnectivityTestResult())
     private var _mLabUploadResult = MutableStateFlow(ConnectivityTestResult())
     private var _mLabDownloadResult = MutableStateFlow(ConnectivityTestResult())
 
@@ -271,8 +271,9 @@ class MainActivityViewModel @Inject constructor(
                         NDTTest.TestType.UPLOAD -> {
                             // Extract RTT from TCPInfo if available during upload test
                             it.tcpInfo?.rtt?.let { rtt ->
-                                _mlabRttResult.value = rtt.toDouble() / 1000.0 // Convert from microseconds to milliseconds
-                                Log.d(TAG, "RTT from Upload test: ${_mlabRttResult.value} ms")
+                                val rttMs = rtt.toDouble() / 1000.0 // microseconds → milliseconds
+                                _mlabRttResult.value = ConnectivityTestResult.Result(rttMs.toString(), Color.Black)
+                                Log.d(TAG, "RTT from Upload test: $rttMs ms")
                             }
                             
                             _mLabUploadResult.value = when(it.status) {
@@ -289,8 +290,9 @@ class MainActivityViewModel @Inject constructor(
                         NDTTest.TestType.DOWNLOAD -> {
                             // Extract RTT from TCPInfo if available during download test
                             it.tcpInfo?.rtt?.let { rtt ->
-                                _mlabRttResult.value = rtt.toDouble() / 1000.0 // Convert from microseconds to milliseconds
-                                Log.d(TAG, "RTT from Download test: ${_mlabRttResult.value} ms")
+                                val rttMs = rtt.toDouble() / 1000.0 // microseconds → milliseconds
+                                _mlabRttResult.value = ConnectivityTestResult.Result(rttMs.toString(), Color.Black)
+                                Log.d(TAG, "RTT from Upload test: $rttMs ms")
                             }
                             
                             _mLabDownloadResult.value = when(it.status) {
@@ -363,7 +365,7 @@ class MainActivityViewModel @Inject constructor(
                         it.second.deviceID,
                         (_mLabUploadResult.value as ConnectivityTestResult.Result).result.toDouble(),
                         (_mLabDownloadResult.value as ConnectivityTestResult.Result).result.toDouble(),
-                        _mlabRttResult.value, // Use RTT from ndt7 TCPInfo
+                        (_mlabRttResult.value as ConnectivityTestResult.Result).result.toDouble(),
                         0.0, // No packet loss information available from ndt7, defaulting to 0
                     )
 
@@ -422,7 +424,7 @@ class MainActivityViewModel @Inject constructor(
     }
 
     private fun resetMLabTestResult() {
-        _mlabRttResult.value = 0.0
+        _mlabRttResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
         _mLabUploadResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
         _mLabDownloadResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
     }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
@@ -269,18 +269,10 @@ class MainActivityViewModel @Inject constructor(
                 .collect{
                     when(it.type) {
                         NDTTest.TestType.UPLOAD -> {
-                            // Extract RTT from TCPInfo if available during upload test
-                            it.tcpInfo?.rtt?.let { rtt ->
-                                val rttMs = rtt.toDouble() / 1000.0 // microseconds → milliseconds
-                                _mlabRttResult.value = ConnectivityTestResult.Result(rttMs.toString(), Color.Black)
-                                Log.d(TAG, "RTT from Upload test: $rttMs ms")
-                            }
-                            
                             _mLabUploadResult.value = when(it.status) {
                                 MLabTestStatus.RUNNING -> { ConnectivityTestResult.Result(it.speed!!, Color.LightGray) }
 
                                 MLabTestStatus.FINISHED -> { ConnectivityTestResult.Result(it.speed!!, Color.Black) }
-
                                 MLabTestStatus.ERROR -> {
                                     _isMLabTestActive.value = false
                                     ConnectivityTestResult.Error(it.errorMsg!!)
@@ -292,7 +284,7 @@ class MainActivityViewModel @Inject constructor(
                             it.tcpInfo?.rtt?.let { rtt ->
                                 val rttMs = rtt.toDouble() / 1000.0 // microseconds → milliseconds
                                 _mlabRttResult.value = ConnectivityTestResult.Result(rttMs.toString(), Color.Black)
-                                Log.d(TAG, "RTT from Upload test: $rttMs ms")
+                                Log.d(TAG, "RTT from Download test: $rttMs ms")
                             }
                             
                             _mLabDownloadResult.value = when(it.status) {

--- a/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabCallback.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabCallback.kt
@@ -2,9 +2,12 @@ package com.lcl.lclmeasurementtool.features.mlab
 
 import net.measurementlab.ndt7.android.NDTTest
 import net.measurementlab.ndt7.android.models.ClientResponse
+import net.measurementlab.ndt7.android.models.Measurement
 
 interface MLabCallback {
     fun onDownloadProgress(clientResponse: ClientResponse)
     fun onUploadProgress(clientResponse: ClientResponse)
+    fun onMeasurementDownloadProgress(measurement: Measurement)
+    fun onMeasurementUploadProgress(measurement: Measurement)
     fun onFinish(clientResponse: ClientResponse?, error: Throwable?, testType: NDTTest.TestType)
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabResult.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabResult.kt
@@ -1,12 +1,14 @@
 package com.lcl.lclmeasurementtool.features.mlab
 
 import net.measurementlab.ndt7.android.NDTTest
+import net.measurementlab.ndt7.android.models.TCPInfo
 
 data class MLabResult(
     val speed: String?,
     val type: NDTTest.TestType,
     val errorMsg: String?,
-    val status: MLabTestStatus
+    val status: MLabTestStatus,
+    val tcpInfo: TCPInfo? = null
 )
 
 enum class MLabTestStatus {

--- a/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
@@ -65,7 +65,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
 
                 override fun onMeasurementUploadProgress(measurement: Measurement) {
                     Log.d(TAG, "on measurement upload")
-                    channel.trySend(MLabResult(null, TestType.DOWNLOAD, null, MLabTestStatus.RUNNING, measurement.tcpInfo))
+//                    channel.trySend(MLabResult(null, TestType.UPLOAD, null, MLabTestStatus.RUNNING, measurement.tcpInfo))
                 }
 
                 override fun onFinish(

--- a/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
@@ -4,9 +4,7 @@ import android.util.Log
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import net.measurementlab.ndt7.android.NDTTest
-import net.measurementlab.ndt7.android.models.AppInfo
 import net.measurementlab.ndt7.android.models.ClientResponse
-import net.measurementlab.ndt7.android.models.Measurement
 import net.measurementlab.ndt7.android.utils.DataConverter
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -14,28 +12,12 @@ import java.util.concurrent.TimeUnit
 class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): NDTTest(httpClient) {
     override fun onDownloadProgress(clientResponse: ClientResponse) {
         super.onDownloadProgress(clientResponse)
-        Log.d(TAG, "onDownloadProgress - measurement: ${clientResponse.measurement}, tcpInfo: ${clientResponse.measurement?.tcpInfo}")
         callback.onDownloadProgress(clientResponse)
     }
 
     override fun onUploadProgress(clientResponse: ClientResponse) {
         super.onUploadProgress(clientResponse)
-        Log.d(TAG, "onUploadProgress - measurement: ${clientResponse.measurement}, tcpInfo: ${clientResponse.measurement?.tcpInfo}")
         callback.onUploadProgress(clientResponse)
-    }
-    
-    override fun onMeasurementDownloadProgress(measurement: Measurement) {
-        super.onMeasurementDownloadProgress(measurement)
-        Log.d(TAG, "onMeasurementDownloadProgress - tcpInfo: ${measurement.tcpInfo}")
-        // Note: We don't need to override this method to get RTT. The measurement is passed along
-        // in the ClientResponse through the onDownloadProgress callback.
-    }
-
-    override fun onMeasurementUploadProgress(measurement: Measurement) {
-        super.onMeasurementUploadProgress(measurement)
-        Log.d(TAG, "onMeasurementUploadProgress - tcpInfo: ${measurement.tcpInfo}")
-        // Note: We don't need to override this method to get RTT. The measurement is passed along
-        // in the ClientResponse through the onUploadProgress callback.
     }
 
     override fun onFinished(
@@ -44,7 +26,6 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
         testType: TestType
     ) {
         super.onFinished(clientResponse, error, testType)
-        Log.d(TAG, "onFinished - type: $testType, measurement: ${clientResponse?.measurement}, tcpInfo: ${clientResponse?.measurement?.tcpInfo}")
         callback.onFinish(clientResponse, error, testType)
     }
 
@@ -57,7 +38,6 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client download is $speed")
                     val measurement = clientResponse.measurement
-                    Log.d(TAG, "Download measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                     channel.trySend(MLabResult(speed, TestType.DOWNLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
@@ -65,7 +45,6 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client upload is $speed")
                     val measurement = clientResponse.measurement
-                    Log.d(TAG, "Upload measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                     channel.trySend(MLabResult(speed, TestType.UPLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
@@ -77,7 +56,6 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     if (clientResponse != null) {
                         Log.d(TAG, "client finish test $testType")
                         val measurement = clientResponse.measurement
-                        Log.d(TAG, "Finish measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                         channel.trySend(MLabResult(DataConverter.convertToMbps(clientResponse), testType, null, MLabTestStatus.FINISHED, measurement?.tcpInfo))
                     } else {
                         channel.trySend(MLabResult(null, testType, error?.message, MLabTestStatus.ERROR))

--- a/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
@@ -4,7 +4,9 @@ import android.util.Log
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import net.measurementlab.ndt7.android.NDTTest
+import net.measurementlab.ndt7.android.models.AppInfo
 import net.measurementlab.ndt7.android.models.ClientResponse
+import net.measurementlab.ndt7.android.models.Measurement
 import net.measurementlab.ndt7.android.utils.DataConverter
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -12,12 +14,28 @@ import java.util.concurrent.TimeUnit
 class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): NDTTest(httpClient) {
     override fun onDownloadProgress(clientResponse: ClientResponse) {
         super.onDownloadProgress(clientResponse)
+        Log.d(TAG, "onDownloadProgress - measurement: ${clientResponse.measurement}, tcpInfo: ${clientResponse.measurement?.tcpInfo}")
         callback.onDownloadProgress(clientResponse)
     }
 
     override fun onUploadProgress(clientResponse: ClientResponse) {
         super.onUploadProgress(clientResponse)
+        Log.d(TAG, "onUploadProgress - measurement: ${clientResponse.measurement}, tcpInfo: ${clientResponse.measurement?.tcpInfo}")
         callback.onUploadProgress(clientResponse)
+    }
+    
+    override fun onMeasurementDownloadProgress(measurement: Measurement) {
+        super.onMeasurementDownloadProgress(measurement)
+        Log.d(TAG, "onMeasurementDownloadProgress - tcpInfo: ${measurement.tcpInfo}")
+        // Note: We don't need to override this method to get RTT. The measurement is passed along
+        // in the ClientResponse through the onDownloadProgress callback.
+    }
+
+    override fun onMeasurementUploadProgress(measurement: Measurement) {
+        super.onMeasurementUploadProgress(measurement)
+        Log.d(TAG, "onMeasurementUploadProgress - tcpInfo: ${measurement.tcpInfo}")
+        // Note: We don't need to override this method to get RTT. The measurement is passed along
+        // in the ClientResponse through the onUploadProgress callback.
     }
 
     override fun onFinished(
@@ -26,6 +44,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
         testType: TestType
     ) {
         super.onFinished(clientResponse, error, testType)
+        Log.d(TAG, "onFinished - type: $testType, measurement: ${clientResponse?.measurement}, tcpInfo: ${clientResponse?.measurement?.tcpInfo}")
         callback.onFinish(clientResponse, error, testType)
     }
 
@@ -38,6 +57,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client download is $speed")
                     val measurement = clientResponse.measurement
+                    Log.d(TAG, "Download measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                     channel.trySend(MLabResult(speed, TestType.DOWNLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
@@ -45,6 +65,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client upload is $speed")
                     val measurement = clientResponse.measurement
+                    Log.d(TAG, "Upload measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                     channel.trySend(MLabResult(speed, TestType.UPLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
@@ -56,6 +77,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     if (clientResponse != null) {
                         Log.d(TAG, "client finish test $testType")
                         val measurement = clientResponse.measurement
+                        Log.d(TAG, "Finish measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                         channel.trySend(MLabResult(DataConverter.convertToMbps(clientResponse), testType, null, MLabTestStatus.FINISHED, measurement?.tcpInfo))
                     } else {
                         channel.trySend(MLabResult(null, testType, error?.message, MLabTestStatus.ERROR))

--- a/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
@@ -37,13 +37,15 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                 override fun onDownloadProgress(clientResponse: ClientResponse) {
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client download is $speed")
-                    channel.trySend(MLabResult(speed, TestType.DOWNLOAD, null, MLabTestStatus.RUNNING))
+                    val measurement = clientResponse.measurement
+                    channel.trySend(MLabResult(speed, TestType.DOWNLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
                 override fun onUploadProgress(clientResponse: ClientResponse) {
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client upload is $speed")
-                    channel.trySend(MLabResult(speed, TestType.UPLOAD, null, MLabTestStatus.RUNNING))
+                    val measurement = clientResponse.measurement
+                    channel.trySend(MLabResult(speed, TestType.UPLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
                 override fun onFinish(
@@ -53,7 +55,8 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                 ) {
                     if (clientResponse != null) {
                         Log.d(TAG, "client finish test $testType")
-                        channel.trySend(MLabResult(DataConverter.convertToMbps(clientResponse), testType, null, MLabTestStatus.FINISHED))
+                        val measurement = clientResponse.measurement
+                        channel.trySend(MLabResult(DataConverter.convertToMbps(clientResponse), testType, null, MLabTestStatus.FINISHED, measurement?.tcpInfo))
                     } else {
                         channel.trySend(MLabResult(null, testType, error?.message, MLabTestStatus.ERROR))
                     }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/features/mlab/MLabRunner.kt
@@ -4,7 +4,9 @@ import android.util.Log
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import net.measurementlab.ndt7.android.NDTTest
+import net.measurementlab.ndt7.android.models.AppInfo
 import net.measurementlab.ndt7.android.models.ClientResponse
+import net.measurementlab.ndt7.android.models.Measurement
 import net.measurementlab.ndt7.android.utils.DataConverter
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
@@ -12,12 +14,28 @@ import java.util.concurrent.TimeUnit
 class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): NDTTest(httpClient) {
     override fun onDownloadProgress(clientResponse: ClientResponse) {
         super.onDownloadProgress(clientResponse)
+        Log.d(TAG, "onDownloadProgress - measurement: ${clientResponse.measurement}, tcpInfo: ${clientResponse.measurement?.tcpInfo}")
         callback.onDownloadProgress(clientResponse)
     }
 
     override fun onUploadProgress(clientResponse: ClientResponse) {
         super.onUploadProgress(clientResponse)
+        Log.d(TAG, "onUploadProgress - measurement: ${clientResponse.measurement}, tcpInfo: ${clientResponse.measurement?.tcpInfo}")
         callback.onUploadProgress(clientResponse)
+    }
+
+    override fun onMeasurementDownloadProgress(measurement: Measurement) {
+        super.onMeasurementDownloadProgress(measurement)
+        Log.d(TAG, "onMeasurementDownloadProgress - tcpInfo: ${measurement.tcpInfo}")
+        // Note: We don't need to override this method to get RTT. The measurement is passed along
+        // in the ClientResponse through the onDownloadProgress callback.
+    }
+
+    override fun onMeasurementUploadProgress(measurement: Measurement) {
+        super.onMeasurementUploadProgress(measurement)
+        Log.d(TAG, "onMeasurementUploadProgress - tcpInfo: ${measurement.tcpInfo}")
+        // Note: We don't need to override this method to get RTT. The measurement is passed along
+        // in the ClientResponse through the onUploadProgress callback.
     }
 
     override fun onFinished(
@@ -26,6 +44,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
         testType: TestType
     ) {
         super.onFinished(clientResponse, error, testType)
+        Log.d(TAG, "onFinished - type: $testType, measurement: ${clientResponse?.measurement}, tcpInfo: ${clientResponse?.measurement?.tcpInfo}")
         callback.onFinish(clientResponse, error, testType)
     }
 
@@ -38,6 +57,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client download is $speed")
                     val measurement = clientResponse.measurement
+                    Log.d(TAG, "Download measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                     channel.trySend(MLabResult(speed, TestType.DOWNLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
@@ -45,6 +65,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     val speed = DataConverter.convertToMbps(clientResponse)
                     Log.d(TAG, "client upload is $speed")
                     val measurement = clientResponse.measurement
+                    Log.d(TAG, "Upload measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                     channel.trySend(MLabResult(speed, TestType.UPLOAD, null, MLabTestStatus.RUNNING, measurement?.tcpInfo))
                 }
 
@@ -56,6 +77,7 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
                     if (clientResponse != null) {
                         Log.d(TAG, "client finish test $testType")
                         val measurement = clientResponse.measurement
+                        Log.d(TAG, "Finish measurement: $measurement, tcpInfo: ${measurement?.tcpInfo}")
                         channel.trySend(MLabResult(DataConverter.convertToMbps(clientResponse), testType, null, MLabTestStatus.FINISHED, measurement?.tcpInfo))
                     } else {
                         channel.trySend(MLabResult(null, testType, error?.message, MLabTestStatus.ERROR))
@@ -84,4 +106,3 @@ class MLabRunner(httpClient: OkHttpClient, private val callback: MLabCallback): 
         }
     }
 }
-

--- a/app/src/main/java/com/lcl/lclmeasurementtool/model/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/model/viewmodels/SettingsViewModel.kt
@@ -1,11 +1,19 @@
 package com.lcl.lclmeasurementtool.model.viewmodels
 
-import androidx.lifecycle.ViewModel
+import android.app.Application
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.lcl.lclmeasurementtool.model.repository.ConnectivityRepository
+import com.lcl.lclmeasurementtool.model.repository.SignalStrengthRepository
 import com.lcl.lclmeasurementtool.model.repository.UserDataRepository
+import com.lcl.lclmeasurementtool.util.CsvExporter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -14,7 +22,10 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val userDataRepository: UserDataRepository,
-) : ViewModel() {
+    private val signalStrengthRepository: SignalStrengthRepository,
+    private val connectivityRepository: ConnectivityRepository,
+    application: Application
+) : AndroidViewModel(application) {
 
     val shouldShowData: StateFlow<Boolean> = userDataRepository
         .userData
@@ -25,6 +36,9 @@ class SettingsViewModel @Inject constructor(
             initialValue = false
         )
 
+    // Holds the URI of the exported file after a successful export
+    private var _exportedFileUri: Uri? = null
+    val exportedFileUri get() = _exportedFileUri
 
     fun toggleShowData(showData: Boolean) {
         viewModelScope.launch {
@@ -32,10 +46,94 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun logout()  {
+    fun logout() {
         viewModelScope.launch {
             userDataRepository.logout()
         }
     }
 
+    /**
+     * Export signal strength data to a CSV file
+     */
+    fun exportSignalStrengthData(onComplete: (Uri?) -> Unit) {
+        viewModelScope.launch {
+            try {
+                val signalData = signalStrengthRepository.getAll().first()
+                if (signalData.isEmpty()) {
+                    showToast("No signal strength data to export")
+                    onComplete(null)
+                    return@launch
+                }
+
+                val uri = CsvExporter.exportSignalStrengthToCsv(getApplication(), signalData)
+                _exportedFileUri = uri
+                
+                if (uri != null) {
+                    showToast("Signal strength data exported successfully")
+                    shareFile(uri, "Signal Strength Data", "text/csv")
+                } else {
+                    showToast("Failed to export signal strength data")
+                }
+                
+                onComplete(uri)
+            } catch (e: Exception) {
+                showToast("Error exporting signal strength data: ${e.message}")
+                onComplete(null)
+            }
+        }
+    }
+
+    /**
+     * Export connectivity data to a CSV file
+     */
+    fun exportConnectivityData(onComplete: (Uri?) -> Unit) {
+        viewModelScope.launch {
+            try {
+                val connectivityData = connectivityRepository.getAll().first()
+                if (connectivityData.isEmpty()) {
+                    showToast("No connectivity data to export")
+                    onComplete(null)
+                    return@launch
+                }
+                
+                val uri = CsvExporter.exportConnectivityToCsv(getApplication(), connectivityData)
+                _exportedFileUri = uri
+                
+                if (uri != null) {
+                    showToast("Connectivity data exported successfully")
+                    shareFile(uri, "Speed Test Data", "text/csv")
+                } else {
+                    showToast("Failed to export connectivity data")
+                }
+                
+                onComplete(uri)
+            } catch (e: Exception) {
+                showToast("Error exporting connectivity data: ${e.message}")
+                onComplete(null)
+            }
+        }
+    }
+    
+    /**
+     * Share a file using Android's share functionality
+     */
+    private fun shareFile(uri: Uri, subject: String, mimeType: String) {
+        val context = getApplication<Application>()
+        val shareIntent = Intent().apply {
+            action = Intent.ACTION_SEND
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, subject)
+            type = mimeType
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        
+        val chooserIntent = Intent.createChooser(shareIntent, "Share $subject")
+        chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(chooserIntent)
+    }
+
+    private fun showToast(message: String) {
+        Toast.makeText(getApplication(), message, Toast.LENGTH_SHORT).show()
+    }
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
@@ -191,7 +191,7 @@ private fun ConnectivityCard(
                             if (numeric > 0) String.format("%.1f", numeric) else "0.0"
                         }
                         else -> {
-                            "Err" // or rttValue.error if you want to display the error message
+                            "0.0" // or rttValue.error if you want to display the error message
                         }
                     }
 

--- a/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
@@ -30,10 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.lcl.lclmeasurementtool.BuildConfig
 import com.lcl.lclmeasurementtool.ConnectivityTestResult
 import com.lcl.lclmeasurementtool.MainActivityViewModel
-import com.lcl.lclmeasurementtool.PingResultState
 import com.lcl.lclmeasurementtool.SignalStrengthResult
-import com.lcl.lclmeasurementtool.features.ping.PingError
-import com.lcl.lclmeasurementtool.features.ping.PingErrorCase
 import kotlinx.coroutines.cancel
 
 @Composable
@@ -48,7 +45,7 @@ fun HomeScreen(modifier: Modifier = Modifier, isOffline: Boolean, mainActivityVi
     val snackbarHostState = remember { SnackbarHostState() }
 
     val isMLabTestActive = mainActivityViewModel.isMLabTestActive.collectAsStateWithLifecycle()
-    val mlabPingResult = mainActivityViewModel.mLabPingResult.collectAsStateWithLifecycle()
+    val mlabRttResult = mainActivityViewModel.mlabRttResult.collectAsStateWithLifecycle()
     val mlabUploadResult = mainActivityViewModel.mlabUploadResult.collectAsStateWithLifecycle()
     val mlabDownloadResult = mainActivityViewModel.mlabDownloadResult.collectAsStateWithLifecycle()
     val signalStrength = mainActivityViewModel.signalStrengthResult.collectAsStateWithLifecycle()
@@ -64,7 +61,7 @@ fun HomeScreen(modifier: Modifier = Modifier, isOffline: Boolean, mainActivityVi
             ConnectivityCard(
                 label = "MLab",
                 modifier = modifier,
-                pingResult = mlabPingResult.value,
+                rttValue = mlabRttResult.value,
                 uploadResult = mlabUploadResult.value,
                 downloadResult = mlabDownloadResult.value
             )
@@ -150,7 +147,7 @@ private fun SignalStrengthCard(
 private fun ConnectivityCard(
     label: String,
     modifier: Modifier = Modifier,
-    pingResult: PingResultState,
+    rttValue: Double,
     uploadResult: ConnectivityTestResult,
     downloadResult: ConnectivityTestResult,
 ) {
@@ -188,25 +185,12 @@ private fun ConnectivityCard(
 
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
-                    var pingNum = "0"
-                    var pingLoss = "0"
-                    when(pingResult) {
-                        is PingResultState.Success -> {
-                            pingNum = pingResult.result.avg!!
-                            pingLoss = pingResult.result.numLoss!!
-                        }
-                        is PingResultState.Error -> {
-                            pingNum = "0"
-                            pingLoss = "0"
-                            if (pingResult.error.code != PingErrorCase.OK) {
-                                Log.d("HOMEScreen", pingResult.error.message ?: "Error occurred")
-                                // TODO: show error message
-                            }
-                        }
-                    }
-
-                    DataEntry(icon = Rounded.NetworkPing, text = "$pingNum ms")
-                    DataEntry(icon = Rounded.Cancel, text = "$pingLoss % loss")
+                    // Format RTT to one decimal place
+                    val formattedRtt = if (rttValue > 0) String.format("%.1f", rttValue) else "0.0"
+                    
+                    DataEntry(icon = Rounded.NetworkPing, text = "$formattedRtt ms")
+                    // We no longer have packet loss data from ndt7, so we'll remove this or set it to 0
+                    DataEntry(icon = Rounded.Cancel, text = "0 % loss")
                 }
             }
         }
@@ -233,13 +217,13 @@ fun ConnectivityCardPreview() {
 
     Column {
         ConnectivityCard(label = "IperfRunner",
-            pingResult = PingResultState.Error(PingError(PingErrorCase.OK, null)),
+            rttValue = 15.2,
             uploadResult = ConnectivityTestResult.Result("1", Color.Blue),
             downloadResult = ConnectivityTestResult.Result("1", Color.Green)
         )
 
         ConnectivityCard(label = "MLab",
-            pingResult = PingResultState.Error(PingError(PingErrorCase.OK, null)),
+            rttValue = 23.7,
             uploadResult = ConnectivityTestResult.Result("1", Color.Blue),
             downloadResult = ConnectivityTestResult.Result("1", Color.Green)
         )

--- a/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
@@ -147,7 +147,7 @@ private fun SignalStrengthCard(
 private fun ConnectivityCard(
     label: String,
     modifier: Modifier = Modifier,
-    rttValue: Double,
+    rttValue: ConnectivityTestResult,
     uploadResult: ConnectivityTestResult,
     downloadResult: ConnectivityTestResult,
 ) {
@@ -185,13 +185,20 @@ private fun ConnectivityCard(
 
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
-                    // Format RTT to one decimal place
-                    val formattedRtt = if (rttValue > 0) String.format("%.1f", rttValue) else "0.0"
-                    
+                    val formattedRtt = when (rttValue) {
+                        is ConnectivityTestResult.Result -> {
+                            val numeric = rttValue.result.toDoubleOrNull() ?: 0.0
+                            if (numeric > 0) String.format("%.1f", numeric) else "0.0"
+                        }
+                        else -> {
+                            "Err" // or rttValue.error if you want to display the error message
+                        }
+                    }
+
                     DataEntry(icon = Rounded.NetworkPing, text = "$formattedRtt ms")
-                    // We no longer have packet loss data from ndt7, so we'll remove this or set it to 0
                     DataEntry(icon = Rounded.Cancel, text = "0 % loss")
                 }
+
             }
         }
         Box(modifier = Modifier.fillMaxWidth()) {
@@ -216,14 +223,16 @@ fun DataEntry(icon: ImageVector, text: String) {
 fun ConnectivityCardPreview() {
 
     Column {
-        ConnectivityCard(label = "IperfRunner",
-            rttValue = 15.2,
+        ConnectivityCard(
+            label = "IperfRunner",
+            rttValue = ConnectivityTestResult.Result("1", Color.Red),
             uploadResult = ConnectivityTestResult.Result("1", Color.Blue),
             downloadResult = ConnectivityTestResult.Result("1", Color.Green)
         )
 
-        ConnectivityCard(label = "MLab",
-            rttValue = 23.7,
+        ConnectivityCard(
+            label = "MLab",
+            rttValue = ConnectivityTestResult.Result("1", Color.Red),
             uploadResult = ConnectivityTestResult.Result("1", Color.Blue),
             downloadResult = ConnectivityTestResult.Result("1", Color.Green)
         )

--- a/app/src/main/java/com/lcl/lclmeasurementtool/ui/SettingsView.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/ui/SettingsView.kt
@@ -34,13 +34,33 @@ fun SettingsDialog(
     onDismiss: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-
+    val context = LocalContext.current
     val showData = viewModel.shouldShowData.collectAsStateWithLifecycle()
+    
+    // Export functions that handle the result
+    val exportSignalStrength: () -> Unit = {
+        viewModel.exportSignalStrengthData { uri ->
+            uri?.let {
+                // Optionally show a share intent or handle the URI
+            }
+        }
+    }
+    
+    val exportConnectivity: () -> Unit = {
+        viewModel.exportConnectivityData { uri ->
+            uri?.let {
+                // Optionally show a share intent or handle the URI
+            }
+        }
+    }
+    
     SettingDialog(
         onDismiss = onDismiss,
         toggleShowData = viewModel::toggleShowData,
         logout = viewModel::logout,
-        showData = showData.value
+        showData = showData.value,
+        exportSignalStrength = exportSignalStrength,
+        exportConnectivity = exportConnectivity
     )
 }
 
@@ -49,7 +69,9 @@ fun SettingDialog(
     onDismiss: () -> Unit,
     toggleShowData: (Boolean) -> Unit,
     logout: () -> Unit,
-    showData: Boolean
+    showData: Boolean,
+    exportSignalStrength: () -> Unit = {},
+    exportConnectivity: () -> Unit = {}
 ) {
     AlertDialog(
         onDismissRequest = { onDismiss() },
@@ -62,7 +84,13 @@ fun SettingDialog(
         text = {
             Divider()
             Column(Modifier.verticalScroll(rememberScrollState())) {
-                SettingsPanel(onSelectShowData = {toggleShowData(!showData)}, onLogoutClicked = {logout()}, showData = showData)
+                SettingsPanel(
+                    onSelectShowData = {toggleShowData(!showData)}, 
+                    onLogoutClicked = {logout()}, 
+                    showData = showData,
+                    exportSignalStrength = exportSignalStrength,
+                    exportConnectivity = exportConnectivity
+                )
                 Divider(Modifier.padding(top = 8.dp))
                 LinksPanel()
                 VersionInfo()
@@ -85,7 +113,9 @@ fun SettingDialog(
 private fun SettingsPanel(
     onSelectShowData: (Boolean) -> Unit,
     onLogoutClicked: () -> Unit,
-    showData: Boolean
+    showData: Boolean,
+    exportSignalStrength: () -> Unit = {},
+    exportConnectivity: () -> Unit = {}
 ) {
     SettingsDialogSectionTitle(text = "General")
     Column(Modifier.fillMaxWidth(),
@@ -102,8 +132,8 @@ private fun SettingsPanel(
     SettingsDialogSectionTitle(text = "Data Management")
     Column(Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally) {
-        ClickableRow(text = "Export Signal Strength Data", icon = Icons.Rounded.Download, onClick = {})
-        ClickableRow(text = "Export Speed Test Data", icon = Icons.Rounded.Download, onClick = {})
+        ClickableRow(text = "Export Signal Strength Data", icon = Icons.Rounded.Download, onClick = exportSignalStrength)
+        ClickableRow(text = "Export Speed Test Data", icon = Icons.Rounded.Download, onClick = exportConnectivity)
     }
     SettingsDialogSectionTitle(text = "Help")
     Column(Modifier.fillMaxWidth(),
@@ -207,7 +237,9 @@ private fun PreviewSettingsDialog() {
         onDismiss = {},
         toggleShowData = {},
         logout = {},
-        showData = false
+        showData = false,
+        exportSignalStrength = {},
+        exportConnectivity = {}
     )
 }
 //

--- a/app/src/main/java/com/lcl/lclmeasurementtool/util/CsvExporter.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/util/CsvExporter.kt
@@ -1,0 +1,162 @@
+package com.lcl.lclmeasurementtool.util
+
+import android.content.Context
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import com.lcl.lclmeasurementtool.model.datamodel.ConnectivityReportModel
+import com.lcl.lclmeasurementtool.model.datamodel.SignalStrengthReportModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.FileOutputStream
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.*
+
+object CsvExporter {
+
+    /**
+     * Export signal strength data to a CSV file
+     */
+    suspend fun exportSignalStrengthToCsv(
+        context: Context, 
+        data: List<SignalStrengthReportModel>
+    ): Uri? = withContext(Dispatchers.IO) {
+        try {
+            val fileName = "signal_strength_export_${getCurrentDateTime()}.csv"
+            val csvContent = buildSignalStrengthCsv(data)
+            return@withContext saveToFile(context, fileName, csvContent)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return@withContext null
+        }
+    }
+
+    /**
+     * Export connectivity data to a CSV file
+     */
+    suspend fun exportConnectivityToCsv(
+        context: Context,
+        data: List<ConnectivityReportModel>
+    ): Uri? = withContext(Dispatchers.IO) {
+        try {
+            val fileName = "connectivity_export_${getCurrentDateTime()}.csv"
+            val csvContent = buildConnectivityCsv(data)
+            return@withContext saveToFile(context, fileName, csvContent)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            return@withContext null
+        }
+    }
+
+    /**
+     * Build CSV content for signal strength data
+     */
+    private fun buildSignalStrengthCsv(data: List<SignalStrengthReportModel>): String {
+        val csvBuilder = StringBuilder()
+        
+        // Add CSV header
+        csvBuilder.append("Timestamp,Latitude,Longitude,Cell ID,Device ID,Signal Strength (dBm),Signal Level\n")
+        
+        // Add data rows
+        data.forEach { signal ->
+            csvBuilder.append("${signal.timestamp},${signal.latitude},${signal.longitude},")
+            csvBuilder.append("${signal.cellId},${signal.deviceId},${signal.dbm},${signal.levelCode}\n")
+        }
+        
+        return csvBuilder.toString()
+    }
+    
+    /**
+     * Build CSV content for connectivity data
+     */
+    private fun buildConnectivityCsv(data: List<ConnectivityReportModel>): String {
+        val csvBuilder = StringBuilder()
+        
+        // Add CSV header
+        csvBuilder.append("Timestamp,Latitude,Longitude,Cell ID,Device ID,Download Speed,Upload Speed,Ping,Packet Loss\n")
+        
+        // Add data rows
+        data.forEach { connectivity ->
+            csvBuilder.append("${connectivity.timestamp},${connectivity.latitude},${connectivity.longitude},")
+            csvBuilder.append("${connectivity.cellId},${connectivity.deviceId},${connectivity.downloadSpeed},")
+            csvBuilder.append("${connectivity.uploadSpeed},${connectivity.ping},${connectivity.packetLoss}\n")
+        }
+        
+        return csvBuilder.toString()
+    }
+    
+    /**
+     * Save CSV content to a file in the Downloads directory
+     * 
+     * This approach uses ContentResolver for compatibility across Android versions
+     */
+    private fun saveToFile(context: Context, fileName: String, content: String): Uri? {
+        return try {
+            // Use ContentValues and ContentResolver to create a file
+            val contentValues = android.content.ContentValues().apply {
+                put(android.provider.MediaStore.MediaColumns.DISPLAY_NAME, fileName)
+                put(android.provider.MediaStore.MediaColumns.MIME_TYPE, "text/csv")
+                
+                // For API 29+, use the Downloads collection
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                    put(android.provider.MediaStore.MediaColumns.RELATIVE_PATH, "Download")
+                    put(android.provider.MediaStore.Downloads.IS_PENDING, 1)
+                }
+            }
+            
+            // Choose the right content URI based on Android version
+            val contentUri = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                android.provider.MediaStore.Downloads.EXTERNAL_CONTENT_URI
+            } else {
+                android.provider.MediaStore.Files.getContentUri("external")
+            }
+            
+            val uri = context.contentResolver.insert(contentUri, contentValues)
+            
+            uri?.let {
+                context.contentResolver.openOutputStream(it)?.use { outputStream ->
+                    outputStream.write(content.toByteArray())
+                    outputStream.flush()
+                }
+                
+                // For API 29+, update IS_PENDING to 0
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                    contentValues.clear()
+                    contentValues.put(android.provider.MediaStore.Downloads.IS_PENDING, 0)
+                    context.contentResolver.update(uri, contentValues, null, null)
+                }
+            }
+            
+            uri
+        } catch (e: Exception) {
+            e.printStackTrace()
+            
+            // Use a simpler fallback method if the MediaStore approach fails
+            try {
+                val downloadsDir = context.getExternalFilesDir(android.os.Environment.DIRECTORY_DOWNLOADS)
+                val file = java.io.File(downloadsDir, fileName)
+                
+                java.io.FileWriter(file).use { writer ->
+                    writer.write(content)
+                }
+                
+                androidx.core.content.FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.fileprovider",
+                    file
+                )
+            } catch (e2: Exception) {
+                e2.printStackTrace()
+                null
+            }
+        }
+    }
+    
+    /**
+     * Get current date and time formatted for filenames
+     */
+    private fun getCurrentDateTime(): String {
+        val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault())
+        return dateFormat.format(Date())
+    }
+}

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-path name="external_files" path="." />
+    <external-cache-path name="external_cache_files" path="." />
+    <external-files-path name="external_files_path" path="." />
+    <files-path name="files" path="." />
+    <cache-path name="cache" path="." />
+</paths>

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/models/ClientResponse.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/models/ClientResponse.kt
@@ -7,8 +7,7 @@ import kotlinx.serialization.Serializable
 data class ClientResponse(
     @SerialName("AppInfo") val appInfo: AppInfo,
     @SerialName("Origin") val origin: String = "client",
-    @SerialName("Test") val test: String,
-    @SerialName("Measurement") val measurement: Measurement? = null
+    @SerialName("Test") val test: String
 )
 
 @Serializable

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/models/ClientResponse.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/models/ClientResponse.kt
@@ -7,7 +7,8 @@ import kotlinx.serialization.Serializable
 data class ClientResponse(
     @SerialName("AppInfo") val appInfo: AppInfo,
     @SerialName("Origin") val origin: String = "client",
-    @SerialName("Test") val test: String
+    @SerialName("Test") val test: String,
+    @SerialName("Measurement") val measurement: Measurement? = null
 )
 
 @Serializable

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/models/HostnameResponse.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/models/HostnameResponse.kt
@@ -17,7 +17,9 @@ data class Result(
     @SerialName("machine")
     val machine: String,
     @SerialName("urls")
-    val urls: Urls
+    val urls: Urls,
+    @SerialName("hostname")
+    var hostname: String
 )
 
 @Serializable

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/models/Measurement.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/models/Measurement.kt
@@ -81,5 +81,7 @@ data class TCPInfo(
     @SerialName("BytesRetrans") val bytesRetrans: Long?,
     @SerialName("DSackDups") val dSackDups: Long?,
     @SerialName("ReordSeen") val reordSeen: Long?,
+    @SerialName("RcvOooPack") val rcvOooPack: Long?,
+    @SerialName("SndWnd") val sndWnd: Long?,
     @SerialName("ElapsedTime") val elapsedTime: Long?
 )


### PR DESCRIPTION
Has code that has replaced the in-house Ping functionality with RTT values from MLab's TCPInfo as well as code to read the database and export to CSV files through settings