### PR TITLE
feat: implement site-based cell ID matching

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,6 +176,7 @@ dependencies {
     // third-party lib
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
+    implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0'
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation 'com.github.kongzue.DialogX:DialogX:0.0.43.beta13'
     implementation 'com.github.getActivity:XXPermissions:16.6'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,7 +176,7 @@ dependencies {
     // third-party lib
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
-    implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation "com.squareup.okhttp3:okhttp:$okhttp_version"
     implementation 'com.github.kongzue.DialogX:DialogX:0.0.43.beta13'
     implementation 'com.github.getActivity:XXPermissions:16.6'

--- a/app/src/main/java/com/lcl/lclmeasurementtool/constants/NetworkConstants.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/constants/NetworkConstants.kt
@@ -3,7 +3,7 @@ package com.lcl.lclmeasurementtool.constants
 class NetworkConstants {
 
     companion object {
-        const val URL = "https://coverage.seattlecommunitynetwork.org/api/"
+        const val URL = "http://localhost:3000/api/"
         const val REGISTRATION_ENDPOINT = "register"
         const val SIGNAL_ENDPOINT = "report_signal"
         const val CONNECTIVITY_ENDPOINT = "report_measurement"

--- a/app/src/main/java/com/lcl/lclmeasurementtool/constants/NetworkConstants.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/constants/NetworkConstants.kt
@@ -3,7 +3,7 @@ package com.lcl.lclmeasurementtool.constants
 class NetworkConstants {
 
     companion object {
-        const val URL = "http://localhost:3000/api/"
+        const val URL = "https://coverage.seattlecommunitynetwork.org/api/"
         const val REGISTRATION_ENDPOINT = "register"
         const val SIGNAL_ENDPOINT = "report_signal"
         const val CONNECTIVITY_ENDPOINT = "report_measurement"

--- a/app/src/main/java/com/lcl/lclmeasurementtool/datasource/SignalStrengthDataSource.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/datasource/SignalStrengthDataSource.kt
@@ -10,6 +10,7 @@ import android.telephony.*
 import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.getSystemService
+import com.lcl.lclmeasurementtool.model.datamodel.Site
 import com.lcl.lclmeasurementtool.telephony.SignalStrengthMonitor
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.FlowPreview
@@ -18,6 +19,10 @@ import kotlinx.coroutines.flow.*
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import javax.inject.Inject
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
 
 class SignalStrengthDataSource @Inject constructor(
     @ApplicationContext private val context: Context
@@ -51,6 +56,62 @@ class SignalStrengthDataSource @Inject constructor(
             }
             else -> "unknown"
         }
+    }
+
+    override fun getCellIDFromSite(latitude: Double, longitude: Double, sites: List<Site>): String? {
+        // Find the nearest site
+        val nearestSite = sites.minByOrNull { site ->
+            calculateDistance(latitude, longitude, site.latitude, site.longitude)
+        }
+        
+        // Check if point is within site boundaries or within reasonable distance
+        nearestSite?.let { site ->
+            val distance = calculateDistance(latitude, longitude, site.latitude, site.longitude)
+            
+            // If boundaries are defined, check if point is inside
+            if (site.boundaries != null && site.boundaries.isNotEmpty()) {
+                if (isPointInPolygon(latitude, longitude, site.boundaries)) {
+                    return site.cellIds?.firstOrNull() ?: site.name
+                }
+            } else {
+                // Otherwise use distance threshold (e.g., 500 meters)
+                if (distance < 0.5) { // 500 meters in km
+                    return site.cellIds?.firstOrNull() ?: site.name
+                }
+            }
+        }
+        
+        return null
+    }
+
+    private fun calculateDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
+        val earthRadius = 6371.0 // km
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLon = Math.toRadians(lon2 - lon1)
+        val a = sin(dLat / 2) * sin(dLat / 2) +
+                cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) *
+                sin(dLon / 2) * sin(dLon / 2)
+        val c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return earthRadius * c
+    }
+
+    private fun isPointInPolygon(latitude: Double, longitude: Double, polygon: List<List<Double>>): Boolean {
+        var inside = false
+        var j = polygon.size - 1
+        
+        for (i in polygon.indices) {
+            val xi = polygon[i][0]
+            val yi = polygon[i][1]
+            val xj = polygon[j][0]
+            val yj = polygon[j][1]
+            
+            val intersect = ((yi > longitude) != (yj > longitude)) &&
+                    (latitude < (xj - xi) * (longitude - yi) / (yj - yi) + xi)
+            if (intersect) inside = !inside
+            j = i
+        }
+        
+        return inside
     }
 
     @OptIn(FlowPreview::class)

--- a/app/src/main/java/com/lcl/lclmeasurementtool/datasource/SignalStrengthDataSource.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/datasource/SignalStrengthDataSource.kt
@@ -84,6 +84,8 @@ class SignalStrengthDataSource @Inject constructor(
         return null
     }
 
+    // Calculates the great circle distance between two points given their latitude and longitude
+
     private fun calculateDistance(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
         val earthRadius = 6371.0 // km
         val dLat = Math.toRadians(lat2 - lat1)

--- a/app/src/main/java/com/lcl/lclmeasurementtool/model/datamodel/Site.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/model/datamodel/Site.kt
@@ -1,0 +1,17 @@
+package com.lcl.lclmeasurementtool.model.datamodel
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Site(
+    @SerialName("identity") val identity: String,
+    @SerialName("name") val name: String,
+    @SerialName("latitude") val latitude: Double,
+    @SerialName("longitude") val longitude: Double,
+    @SerialName("status") val status: String,
+    @SerialName("address") val address: String,
+    @SerialName("cell_ids") val cellIds: List<String>? = null,
+    @SerialName("color") val color: String? = null,
+    @SerialName("boundaries") val boundaries: List<List<Double>>? = null
+)

--- a/app/src/main/java/com/lcl/lclmeasurementtool/model/repository/LCLApiRepository.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/model/repository/LCLApiRepository.kt
@@ -1,5 +1,6 @@
 package com.lcl.lclmeasurementtool.model.repository
 
+import com.lcl.lclmeasurementtool.model.datamodel.Site
 import com.lcl.lclmeasurementtool.networking.RetrofitLCLNetwork
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -12,4 +13,5 @@ class LCLApiRepository @Inject constructor(
     override suspend fun register(registration: String): ResponseBody = dataSource.register(registration)
     override suspend fun uploadConnectivity(connectivityReportModel: String): ResponseBody = dataSource.uploadConnectivity(connectivityReportModel)
     override suspend fun uploadSignalStrength(signalStrengthReportModel: String): ResponseBody = dataSource.uploadSignalStrength(signalStrengthReportModel)
+    override suspend fun getSites(): List<Site> = dataSource.getSites()
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/model/repository/NetworkApiRepository.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/model/repository/NetworkApiRepository.kt
@@ -1,5 +1,6 @@
 package com.lcl.lclmeasurementtool.model.repository
 
+import com.lcl.lclmeasurementtool.model.datamodel.Site
 import okhttp3.ResponseBody
 import retrofit2.Response
 import retrofit2.http.Body
@@ -8,4 +9,5 @@ interface NetworkApiRepository {
     suspend fun register(@Body registration: String): ResponseBody
     suspend fun uploadSignalStrength(@Body signalStrengthReportModel: String): ResponseBody
     suspend fun uploadConnectivity(@Body connectivityReportModel: String): ResponseBody
+    suspend fun getSites(): List<Site>
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/model/repository/SiteRepository.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/model/repository/SiteRepository.kt
@@ -1,0 +1,28 @@
+package com.lcl.lclmeasurementtool.model.repository
+
+import android.util.Log
+import com.lcl.lclmeasurementtool.model.datamodel.Site
+import com.lcl.lclmeasurementtool.networking.RetrofitLCLNetwork
+import javax.inject.Inject
+
+interface SiteRepository {
+    suspend fun getSites(): List<Site>
+}
+
+class LCLSiteRepository @Inject constructor(
+    private val dataSource: RetrofitLCLNetwork
+) : SiteRepository {
+    
+    companion object {
+        private const val TAG = "LCLSiteRepository"
+    }
+    
+    override suspend fun getSites(): List<Site> {
+        return try {
+            dataSource.getSites()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to fetch sites: ${e.message}", e)
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/java/com/lcl/lclmeasurementtool/modules/DataModule.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/modules/DataModule.kt
@@ -58,4 +58,9 @@ interface DataModule {
     fun bindsConnectivityRepository(
         measurementRepository: ConnectivityRepository
     ): HistoryDataRepository<ConnectivityReportModel>
+
+    @Binds
+    fun bindsSiteRepository(
+        lclSiteRepository: LCLSiteRepository
+    ): SiteRepository
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/networking/NetworkAPI.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/networking/NetworkAPI.kt
@@ -1,15 +1,13 @@
 package com.lcl.lclmeasurementtool.networking
 
-import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.lcl.lclmeasurementtool.constants.NetworkConstants
 import com.lcl.lclmeasurementtool.model.datamodel.Site
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -37,13 +35,11 @@ private interface NetworkAPI {
 
 @Singleton
 class RetrofitLCLNetwork {
-    private val json = Json { ignoreUnknownKeys = true }
-    
     private val networkApi: NetworkAPI by lazy {
         Retrofit.Builder()
             .client(OkHttpClient())
             .addConverterFactory(ScalarsConverterFactory.create())
-            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .addConverterFactory(GsonConverterFactory.create())
             .baseUrl(NetworkConstants.URL)
             .build().create(NetworkAPI::class.java)
     }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/networking/NetworkAPI.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/networking/NetworkAPI.kt
@@ -1,13 +1,16 @@
 package com.lcl.lclmeasurementtool.networking
 
 import com.lcl.lclmeasurementtool.constants.NetworkConstants
+import com.lcl.lclmeasurementtool.model.datamodel.Site
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.POST
 import javax.inject.Singleton
@@ -25,6 +28,9 @@ private interface NetworkAPI {
     @Headers("Content-Type: ${NetworkConstants.MEDIA_TYPE}")
     @POST(value = NetworkConstants.CONNECTIVITY_ENDPOINT)
     suspend fun uploadConnectivity(@Body connectivityReportModel: String): ResponseBody
+
+    @GET("/api/sites")
+    suspend fun getSites(): List<Site>
 }
 
 @Singleton
@@ -33,6 +39,7 @@ class RetrofitLCLNetwork {
         Retrofit.Builder()
             .client(OkHttpClient())
             .addConverterFactory(ScalarsConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create())
             .baseUrl(NetworkConstants.URL)
             .build().create(NetworkAPI::class.java)
     }
@@ -41,4 +48,5 @@ class RetrofitLCLNetwork {
     suspend fun register(registration: String) = networkApi.register(registration)
     suspend fun uploadSignalStrength(signalStrengthReportModel: String) = networkApi.uploadSignalStrength(signalStrengthReportModel)
     suspend fun uploadConnectivity(connectivityReportModel: String) = networkApi.uploadConnectivity(connectivityReportModel)
+    suspend fun getSites() = networkApi.getSites()
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/networking/NetworkAPI.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/networking/NetworkAPI.kt
@@ -1,13 +1,15 @@
 package com.lcl.lclmeasurementtool.networking
 
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.lcl.lclmeasurementtool.constants.NetworkConstants
 import com.lcl.lclmeasurementtool.model.datamodel.Site
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Response
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -35,11 +37,13 @@ private interface NetworkAPI {
 
 @Singleton
 class RetrofitLCLNetwork {
+    private val json = Json { ignoreUnknownKeys = true }
+    
     private val networkApi: NetworkAPI by lazy {
         Retrofit.Builder()
             .client(OkHttpClient())
             .addConverterFactory(ScalarsConverterFactory.create())
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .baseUrl(NetworkConstants.URL)
             .build().create(NetworkAPI::class.java)
     }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/telephony/SignalStrengthMonitor.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/telephony/SignalStrengthMonitor.kt
@@ -1,9 +1,11 @@
 package com.lcl.lclmeasurementtool.telephony
 
 import android.telephony.SignalStrength
+import com.lcl.lclmeasurementtool.model.datamodel.Site
 import kotlinx.coroutines.flow.Flow
 
 interface SignalStrengthMonitor {
     val signalStrength: Flow<SignalStrength>
     fun getCellID(): String
+    fun getCellIDFromSite(latitude: Double, longitude: Double, sites: List<Site>): String?
 }


### PR DESCRIPTION
Implements site-based cell ID assignment for measurement reports. The app now fetches configured sites from the API and uses their cell IDs when measurements fall within site boundaries, with automatic fallback to device-detected cell IDs.