### PR TITLE
Fix Apple Silicon protobuf tool selection

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,12 +51,6 @@ def getVersionNameFromProperties() {
     return "$major.$minor.$patch"
 }
 
-def isAppleSiliconMac() {
-    def osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT)
-    def osArch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT)
-    return osName.contains("mac") && (osArch == "aarch64" || osArch == "arm64")
-}
-
 android {
     namespace "com.lcl.lclmeasurementtool"
     compileSdkVersion 35
@@ -216,9 +210,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = isAppleSiliconMac() ?
-                "com.google.protobuf:protoc:3.21.12" :
-                "com.google.protobuf:protoc:3.14.0"
+        artifact = "com.google.protobuf:protoc:3.21.12"
     }
 
     // Generates the java Protobuf-lite code for the Protobufs in this project. See

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,12 @@ def getVersionNameFromProperties() {
     return "$major.$minor.$patch"
 }
 
+def isAppleSiliconMac() {
+    def osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT)
+    def osArch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT)
+    return osName.contains("mac") && (osArch == "aarch64" || osArch == "arm64")
+}
+
 android {
     namespace "com.lcl.lclmeasurementtool"
     compileSdkVersion 35
@@ -210,7 +216,9 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.14.0"
+        artifact = isAppleSiliconMac() ?
+                "com.google.protobuf:protoc:3.21.12" :
+                "com.google.protobuf:protoc:3.14.0"
     }
 
     // Generates the java Protobuf-lite code for the Protobufs in this project. See


### PR DESCRIPTION
## Summary
- detect Apple Silicon Macs in the app Gradle build
- use protoc 3.21.12 on Apple Silicon to avoid missing arm64 artifacts
- keep the existing protoc 3.14.0 selection for other environments

## Testing
- ./gradlew assembleDebug