### PR TITLE
Prepare release workflow for AAB builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,7 @@ env:
 on:
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Decode Android keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          base64 --decode <<< "$ANDROID_KEYSTORE_BASE64" > "$RUNNER_TEMP/release-keystore.jks"
+
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v3
         with:
@@ -44,3 +50,19 @@ jobs:
         uses: gradle/gradle-build-action@v3
         with:
           arguments: app:testDemoDebugUnitTest
+
+      - name: Build full release AAB
+        uses: gradle/gradle-build-action@v3
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release-keystore.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        with:
+          arguments: bundleFullRelease
+
+      - name: Upload full release AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-release-aab
+          path: app/build/outputs/bundle/fullRelease/app-full-release.aab

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           echo "RELEASE_AAB_DIR=$(dirname "$artifact_path")" >> "$GITHUB_ENV"
 
       - name: Write Play service account key
-        if: ${{ inputs.upload_to_play }}
+        if: ${{ inputs.upload_to_play && github.ref == 'refs/heads/main' }}
         env:
           PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
         run: |
@@ -74,7 +74,7 @@ jobs:
           path: ${{ env.RELEASE_AAB_PATH }}
 
       - name: Upload signed bundle to Google Play internal testing
-        if: ${{ inputs.upload_to_play }}
+        if: ${{ inputs.upload_to_play && github.ref == 'refs/heads/main' }}
         uses: gradle/gradle-build-action@v3
         env:
           PLAY_STORE_JSON_PATH: ${{ runner.temp }}/play-account.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,30 +44,14 @@ jobs:
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
-          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-keystore.jks"
+          base64 --decode <<< "$ANDROID_KEYSTORE_BASE64" > "$RUNNER_TEMP/release-keystore.jks"
 
       - name: Write Play service account key
         if: ${{ inputs.upload_to_play }}
         env:
           PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
         run: |
-          python - <<'PY'
-          import base64
-          import json
-          import os
-          from pathlib import Path
-
-          secret = os.environ["PLAY_STORE_JSON_KEY"]
-          output_path = Path(os.environ["RUNNER_TEMP"]) / "play-account.json"
-
-          try:
-              decoded = base64.b64decode(secret, validate=True).decode("utf-8")
-              json.loads(decoded)
-              output_path.write_text(decoded, encoding="utf-8")
-          except Exception:
-              json.loads(secret)
-              output_path.write_text(secret, encoding="utf-8")
-          PY
+          cat > "$RUNNER_TEMP/play-account.json" <<< "$PLAY_STORE_JSON_KEY"
 
       - name: Build full release AAB
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      upload_to_play:
+        description: Upload the signed bundle to Google Play internal testing
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   release:
@@ -34,8 +40,42 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Decode Android keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/release-keystore.jks"
+
+      - name: Write Play service account key
+        if: ${{ inputs.upload_to_play }}
+        env:
+          PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
+        run: |
+          python - <<'PY'
+          import base64
+          import json
+          import os
+          from pathlib import Path
+
+          secret = os.environ["PLAY_STORE_JSON_KEY"]
+          output_path = Path(os.environ["RUNNER_TEMP"]) / "play-account.json"
+
+          try:
+              decoded = base64.b64decode(secret, validate=True).decode("utf-8")
+              json.loads(decoded)
+              output_path.write_text(decoded, encoding="utf-8")
+          except Exception:
+              json.loads(secret)
+              output_path.write_text(secret, encoding="utf-8")
+          PY
+
       - name: Build full release AAB
         uses: gradle/gradle-build-action@v3
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release-keystore.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         with:
           arguments: bundleFullRelease
 
@@ -44,3 +84,15 @@ jobs:
         with:
           name: full-release-aab
           path: app/build/outputs/bundle/fullRelease/app-full-release.aab
+
+      - name: Upload signed bundle to Google Play internal testing
+        if: ${{ inputs.upload_to_play }}
+        uses: gradle/gradle-build-action@v3
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release-keystore.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          PLAY_STORE_JSON_PATH: ${{ runner.temp }}/play-account.json
+        with:
+          arguments: publishFullReleaseBundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
           cat > "$RUNNER_TEMP/play-account.json" <<< "$PLAY_STORE_JSON_KEY"
 
       - name: Upload release artifact
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/upload-artifact@v4
         with:
           name: full-release-aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,13 @@
-name: LCL Measurement Tool CI
+name: Release Prep
 
 env:
   main_project_module: app
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
 
     steps:
@@ -35,12 +34,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
+      - name: Build full release AAB
         uses: gradle/gradle-build-action@v3
         with:
-          arguments: app:build
+          arguments: bundleFullRelease
 
-      - name: Run Tests
-        uses: gradle/gradle-build-action@v3
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
         with:
-          arguments: app:testDemoDebugUnitTest
+          name: full-release-aab
+          path: app/build/outputs/bundle/fullRelease/app-full-release.aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ env:
 on:
   workflow_dispatch:
     inputs:
+      android_run_id:
+        description: GitHub Actions run ID from android.yml containing the full-release-aab artifact
+        required: true
+        type: string
       upload_to_play:
         description: Upload the signed bundle to Google Play internal testing
         required: true
@@ -40,11 +44,21 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Decode Android keystore
+      - name: Download release AAB artifact
         env:
-          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          base64 --decode <<< "$ANDROID_KEYSTORE_BASE64" > "$RUNNER_TEMP/release-keystore.jks"
+          mkdir -p "$RUNNER_TEMP/release-artifact"
+          gh run download "${{ inputs.android_run_id }}" \
+            --name full-release-aab \
+            --dir "$RUNNER_TEMP/release-artifact"
+          artifact_path=$(find "$RUNNER_TEMP/release-artifact" -name '*.aab' -type f | head -n 1)
+          if [ -z "$artifact_path" ]; then
+            echo "Could not find downloaded .aab artifact" >&2
+            exit 1
+          fi
+          echo "RELEASE_AAB_PATH=$artifact_path" >> "$GITHUB_ENV"
+          echo "RELEASE_AAB_DIR=$(dirname "$artifact_path")" >> "$GITHUB_ENV"
 
       - name: Write Play service account key
         if: ${{ inputs.upload_to_play }}
@@ -53,30 +67,16 @@ jobs:
         run: |
           cat > "$RUNNER_TEMP/play-account.json" <<< "$PLAY_STORE_JSON_KEY"
 
-      - name: Build full release AAB
-        uses: gradle/gradle-build-action@v3
-        env:
-          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release-keystore.jks
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        with:
-          arguments: bundleFullRelease
-
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: full-release-aab
-          path: app/build/outputs/bundle/fullRelease/app-full-release.aab
+          path: ${{ env.RELEASE_AAB_PATH }}
 
       - name: Upload signed bundle to Google Play internal testing
         if: ${{ inputs.upload_to_play }}
         uses: gradle/gradle-build-action@v3
         env:
-          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/release-keystore.jks
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           PLAY_STORE_JSON_PATH: ${{ runner.temp }}/play-account.json
         with:
-          arguments: publishFullReleaseBundle
+          arguments: publishFullReleaseBundle --artifact-dir ${{ env.RELEASE_AAB_DIR }}

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'kotlin-android'
     id 'com.google.dagger.hilt.android'
     id "com.google.protobuf" version "0.9.4"
+    id "com.github.triplet.play" version "3.12.1"
     id "kotlinx-serialization"
 }
 
@@ -51,6 +52,27 @@ def getVersionNameFromProperties() {
     return "$major.$minor.$patch"
 }
 
+def releaseKeystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+def releaseKeystorePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+def releaseKeyAlias = System.getenv("ANDROID_KEY_ALIAS")
+def releaseKeyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+def playStoreJsonPath = System.getenv("PLAY_STORE_JSON_PATH")
+
+def releaseSigningValues = [
+        releaseKeystorePath,
+        releaseKeystorePassword,
+        releaseKeyAlias,
+        releaseKeyPassword
+]
+def hasAnyReleaseSigningEnv = releaseSigningValues.any { it != null }
+def hasAllReleaseSigningEnv = releaseSigningValues.every { it != null }
+
+if (hasAnyReleaseSigningEnv && !hasAllReleaseSigningEnv) {
+    throw new GradleException(
+            "ANDROID_KEYSTORE_PATH, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, and ANDROID_KEY_PASSWORD must all be set together."
+    )
+}
+
 android {
     namespace "com.lcl.lclmeasurementtool"
     compileSdkVersion 35
@@ -92,10 +114,24 @@ android {
         }
     }
 
+    signingConfigs {
+        release {
+            if (hasAllReleaseSigningEnv) {
+                storeFile file(releaseKeystorePath)
+                storePassword releaseKeystorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            if (hasAllReleaseSigningEnv) {
+                signingConfig signingConfigs.release
+            }
         }
 
         debug {
@@ -124,6 +160,13 @@ android {
 
     kotlinOptions {
         jvmTarget = '17'
+    }
+}
+
+play {
+    track.set("internal")
+    if (playStoreJsonPath != null) {
+        serviceAccountCredentials.set(file(playStoreJsonPath))
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -211,7 +211,7 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.14.0"
+        artifact = "com.google.protobuf:protoc:3.21.12"
     }
 
     // Generates the java Protobuf-lite code for the Protobufs in this project. See


### PR DESCRIPTION
## Summary
- split CI and release preparation into separate workflows
- switch the manual release workflow to build a full release AAB for internal testing prep
- upload the AAB as a workflow artifact
- carry forward the protobuf tool upgrade needed for Apple Silicon builds

## Notes
- local `bundleFullRelease` still hits a separate KAPT/JDK compiler issue on this machine

## Testing
- validated workflow YAML syntax for `android.yml` and `release.yml`