### PR TITLE
Dashboard UI follow-up for ping metrics

### DIFF
--- a/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/MainActivityViewModel.kt
@@ -33,6 +33,9 @@ import net.measurementlab.ndt7.android.NDTTest
 import okhttp3.ResponseBody
 import retrofit2.HttpException
 import retrofit2.Response
+import com.lcl.lclmeasurementtool.constants.PingConstants
+import com.lcl.lclmeasurementtool.features.ping.Ping
+import com.lcl.lclmeasurementtool.features.ping.PingErrorCase
 import com.lcl.lclmeasurementtool.sync.UploadWorker
 import java.io.ByteArrayOutputStream
 import java.security.SecureRandom
@@ -90,6 +93,11 @@ class MainActivityViewModel @Inject constructor(
     private var _mlabRttResult = MutableStateFlow(ConnectivityTestResult())
     private var _mLabUploadResult = MutableStateFlow(ConnectivityTestResult())
     private var _mLabDownloadResult = MutableStateFlow(ConnectivityTestResult())
+
+    private val _pingPacketLoss = MutableStateFlow("-- %")
+    private val _pingRttResult = MutableStateFlow("-- ms")
+    val pingPacketLoss = _pingPacketLoss.asStateFlow()
+    val pingRttResult = _pingRttResult.asStateFlow()
 
     var mlabRttResult = _mlabRttResult.asStateFlow()
     var mlabUploadResult = _mLabUploadResult.asStateFlow()
@@ -288,7 +296,7 @@ class MainActivityViewModel @Inject constructor(
                 .onCompletion {
                     if (it != null) {
                         Log.e(TAG, "Error in MLab test: ${it.message}", it)
-                        _isMLabTestActive.value = false
+                                        _isMLabTestActive.value = false
                     } else {
                         Log.d(TAG, "MLab test completed normally")
                     }
@@ -315,7 +323,7 @@ class MainActivityViewModel @Inject constructor(
                             } else if (it.status == MLabTestStatus.ERROR) {
                                 Log.e(TAG, "Upload test error with null speed: ${it.errorMsg}")
                                 _mLabUploadResult.value = ConnectivityTestResult.Error(it.errorMsg ?: "Unknown error")
-                                _isMLabTestActive.value = false
+                                        _isMLabTestActive.value = false
                             }
                         }
                         NDTTest.TestType.DOWNLOAD -> {
@@ -344,7 +352,7 @@ class MainActivityViewModel @Inject constructor(
                             } else if (it.status == MLabTestStatus.ERROR) {
                                 Log.e(TAG, "Download test error with null speed: ${it.errorMsg}")
                                 _mLabDownloadResult.value = ConnectivityTestResult.Error(it.errorMsg ?: "Unknown error")
-                                _isMLabTestActive.value = false
+                                        _isMLabTestActive.value = false
                             }
                         }
                         else -> { 
@@ -354,7 +362,7 @@ class MainActivityViewModel @Inject constructor(
                 }
         } catch (e: Exception) {
             Log.e(TAG, "Exception during MLab test", e)
-            _isMLabTestActive.value = false
+                                        _isMLabTestActive.value = false
         }
     }
 
@@ -381,6 +389,22 @@ class MainActivityViewModel @Inject constructor(
                 }
 
                 ensureActive()
+
+                // Run ping alongside MLab to get packet loss
+                val pingResult = try {
+                    Ping.start(
+                        address = PingConstants.PING_SERVER_ADDRESS,
+                        times = PingConstants.PING_TIMES,
+                        timeout = PingConstants.PING_TIMEOUT_MS,
+                    )
+                } catch (e: Exception) { null }
+                if (pingResult != null && pingResult.error.code == PingErrorCase.OK) {
+                    _pingRttResult.value = "${pingResult.avg ?: "--"} ms"
+                    _pingPacketLoss.value = "${pingResult.numLoss ?: "--"} %"
+                } else {
+                    _pingRttResult.value = "-- ms"
+                    _pingPacketLoss.value = "-- %"
+                }
 
                 _isMLabTestActive.value = false
                 Log.d(TAG, "upload, download are finished. isMLabTestActive.value=${isMLabTestActive.value}")
@@ -418,7 +442,7 @@ class MainActivityViewModel @Inject constructor(
                         (_mLabUploadResult.value as ConnectivityTestResult.Result).result.toDouble(),
                         (_mLabDownloadResult.value as ConnectivityTestResult.Result).result.toDouble(),
                         (_mlabRttResult.value as ConnectivityTestResult.Result).result.toDouble(),
-                        0.0, // No packet loss information available from ndt7, defaulting to 0
+                        _pingPacketLoss.value.replace(" %", "").toDoubleOrNull() ?: 0.0,
                     )
 
                     saveToDB(signalStrengthReportModel, connectivityReportModel)
@@ -495,6 +519,8 @@ class MainActivityViewModel @Inject constructor(
         _mlabRttResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
         _mLabUploadResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
         _mLabDownloadResult.value = ConnectivityTestResult.Result("0.0", Color.LightGray)
+        _pingPacketLoss.value = "-- %"
+        _pingRttResult.value = "-- ms"
         _isMLabTestActive.value = false
     }
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/constants/PingConstants.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/constants/PingConstants.kt
@@ -1,8 +1,8 @@
 package com.lcl.lclmeasurementtool.constants
 
 object PingConstants {
-    // TODO: Replace with the real ping server endpoint once available
-    const val PING_SERVER_ADDRESS = "ping.example.lcl.test:31337"
+    // Keep google.com as default host while preserving explicit host:port parsing.
+    const val PING_SERVER_ADDRESS = "google.com:443"
     const val PING_TIMES = 5
     const val PING_TIMEOUT_MS = 3000L
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/constants/PingConstants.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/constants/PingConstants.kt
@@ -1,0 +1,8 @@
+package com.lcl.lclmeasurementtool.constants
+
+object PingConstants {
+    // TODO: Replace with the real ping server endpoint once available
+    const val PING_SERVER_ADDRESS = "ping.example.lcl.test:31337"
+    const val PING_TIMES = 5
+    const val PING_TIMEOUT_MS = 3000L
+}

--- a/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons.Filled
 import androidx.compose.material.icons.Icons.Rounded
 import androidx.compose.material.icons.filled.NetworkCheck
@@ -21,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -32,6 +32,14 @@ import com.lcl.lclmeasurementtool.ConnectivityTestResult
 import com.lcl.lclmeasurementtool.MainActivityViewModel
 import com.lcl.lclmeasurementtool.SignalStrengthResult
 import kotlinx.coroutines.cancel
+
+private val DashboardSurface = Color(0xFFF5F7FB)
+private val DashboardTile = Color(0xFFFFFFFF)
+private val DashboardBorder = Color(0xFFE3E8F3)
+private val DashboardTextMuted = Color(0xFF677085)
+private val DashboardTextStrong = Color(0xFF1C2434)
+private val DashboardLive = Color(0xFF1FA56A)
+private val DashboardPending = Color(0xFF7A8090)
 
 @Composable
 fun HomeRoute(isOffline: Boolean, mainActivityViewModel: MainActivityViewModel) {
@@ -51,7 +59,6 @@ fun HomeScreen(modifier: Modifier = Modifier, isOffline: Boolean, mainActivityVi
     val pingPacketLoss = mainActivityViewModel.pingPacketLoss.collectAsStateWithLifecycle()
     val pingRttResult = mainActivityViewModel.pingRttResult.collectAsStateWithLifecycle()
     val signalStrength = mainActivityViewModel.signalStrengthResult.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -117,25 +124,28 @@ private fun SignalStrengthCard(
 
     val (dbm, level) = signalStrengthResult
 
-    Card(colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceVariant),
+    Card(
+        colors = CardDefaults.cardColors(DashboardSurface),
+        border = androidx.compose.foundation.BorderStroke(1.dp, DashboardBorder),
+        shape = RoundedCornerShape(16.dp),
         modifier = Modifier
             .padding(horizontal = 10.dp, vertical = 10.dp)
             .fillMaxWidth()
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier.padding(20.dp)
+            modifier = modifier.padding(horizontal = 16.dp, vertical = 18.dp)
         ) {
 
             Icon(modifier = modifier,
                 imageVector = Filled.SignalCellularAlt,
                 contentDescription = null)
             Spacer(modifier = Modifier.width(12.dp))
-            Text(text = "Signal Strength:", fontSize = fontSize)
+            Text(text = "Signal Strength:", fontSize = fontSize, color = DashboardTextStrong)
             Spacer(modifier = Modifier.width(4.dp))
-            Text(text = "$dbm", fontWeight = FontWeight.Bold, fontSize = fontSize)
+            Text(text = "$dbm", fontWeight = FontWeight.Bold, fontSize = fontSize, color = DashboardTextStrong)
             Spacer(modifier = Modifier.width(4.dp))
-            Text(text = "dBm", fontSize = fontSize)
+            Text(text = "dBm", fontSize = fontSize, color = DashboardTextMuted)
             Spacer(modifier = Modifier.width(20.dp))
             Box(modifier = Modifier
                 .size(10.dp)
@@ -157,61 +167,159 @@ private fun ConnectivityCard(
     packetLoss: String = "-- %",
     pingRtt: String = "-- ms",
 ) {
-    Card(colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceVariant),
+    val uploadText = when (uploadResult) {
+        is ConnectivityTestResult.Result -> "${uploadResult.result} Mbps"
+        else -> "--"
+    }
+    val downloadText = when (downloadResult) {
+        is ConnectivityTestResult.Result -> "${downloadResult.result} Mbps"
+        else -> "--"
+    }
+    val mlabRttText = when (rttValue) {
+        is ConnectivityTestResult.Result -> {
+            val numeric = rttValue.result.toDoubleOrNull() ?: 0.0
+            if (numeric > 0) "${String.format("%.1f", numeric)} ms" else "--"
+        }
+        else -> "--"
+    }
+    val hasLivePing = pingRtt != "-- ms" && packetLoss != "-- %"
+
+    Card(
+        colors = CardDefaults.cardColors(DashboardSurface),
+        border = androidx.compose.foundation.BorderStroke(1.dp, DashboardBorder),
+        shape = RoundedCornerShape(16.dp),
         modifier = Modifier
             .padding(horizontal = 10.dp, vertical = 10.dp)
             .fillMaxWidth()
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier.padding(start = 12.dp, end = 12.dp, top = 12.dp)
+        Column(
+            modifier = modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-
-            Icon(modifier = modifier.padding(end = 12.dp),
-                imageVector = Filled.NetworkCheck,
-                contentDescription = null)
-            Column {
-                Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
-                    when (uploadResult) {
-                        is ConnectivityTestResult.Result -> {
-                            DataEntry(icon = Rounded.CloudUpload, text = "${uploadResult.result} Mbps")
-                        }
-                        else -> DataEntry(icon = Rounded.CloudUpload, text = "0.0 Mbps")
-                    }
-
-
-                    when (downloadResult) {
-                        is ConnectivityTestResult.Result -> {
-                            DataEntry(icon = Rounded.CloudDownload, text = "${downloadResult.result} Mbps")
-                        }
-                        else -> {
-                            DataEntry(icon = Rounded.CloudDownload, text = "0.0 Mbps")
-                        }
-                    }
-
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Filled.NetworkCheck,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp)
+                    )
+                    Text(
+                        text = "Mobile Connectivity",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = DashboardTextStrong
+                    )
                 }
-                Row(horizontalArrangement = Arrangement.spacedBy(20.dp)) {
-                    val formattedRtt = when (rttValue) {
-                        is ConnectivityTestResult.Result -> {
-                            val numeric = rttValue.result.toDoubleOrNull() ?: 0.0
-                            if (numeric > 0) String.format("%.1f", numeric) else "0.0"
-                        }
-                        else -> {
-                            "0.0" // or rttValue.error if you want to display the error message
-                        }
-                    }
-
-                    DataEntry(icon = Rounded.NetworkPing, text = "$formattedRtt ms")
-                    DataEntry(icon = Rounded.Cancel, text = packetLoss)
-                    DataEntry(icon = Rounded.NetworkPing, text = pingRtt)
+                Surface(
+                    shape = RoundedCornerShape(999.dp),
+                    color = if (hasLivePing) DashboardLive.copy(alpha = 0.16f) else DashboardPending.copy(alpha = 0.16f)
+                ) {
+                    Text(
+                        text = if (hasLivePing) "Live" else "Pending",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = if (hasLivePing) DashboardLive else DashboardPending,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 3.dp)
+                    )
                 }
-
             }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                DashboardMetricTile(
+                    icon = Rounded.CloudDownload,
+                    label = "Download",
+                    value = downloadText,
+                    modifier = Modifier.weight(1f)
+                )
+                DashboardMetricTile(
+                    icon = Rounded.CloudUpload,
+                    label = "Upload",
+                    value = uploadText,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                DashboardMetricTile(
+                    icon = Rounded.NetworkPing,
+                    label = "MLab Latency",
+                    value = mlabRttText,
+                    modifier = Modifier.weight(1f)
+                )
+                DashboardMetricTile(
+                    icon = Rounded.Cancel,
+                    label = "Packet Loss",
+                    value = packetLoss,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                DashboardMetricTile(
+                    icon = Rounded.NetworkPing,
+                    label = "Custom Ping",
+                    value = pingRtt,
+                    modifier = Modifier.fillMaxWidth(0.49f),
+                )
+            }
+
+            Text(
+                text = "Powered by $label",
+                fontWeight = FontWeight.Thin,
+                fontSize = 10.sp,
+                color = DashboardTextMuted,
+                modifier = Modifier
+                .align(Alignment.End)
+                .padding(end = 10.dp, bottom = 4.dp)
+            )
         }
-        Box(modifier = Modifier.fillMaxWidth()) {
-            Text(text = "Powered by $label", fontWeight = FontWeight.Thin, fontSize = 10.sp, modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(end = 10.dp, bottom = 4.dp))
+    }
+}
+
+@Composable
+private fun DashboardMetricTile(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        colors = CardDefaults.cardColors(DashboardTile),
+        border = androidx.compose.foundation.BorderStroke(1.dp, DashboardBorder),
+        shape = RoundedCornerShape(12.dp),
+        modifier = modifier
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = DashboardTextMuted
+                )
+            }
+            Text(
+                text = value,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold,
+                color = DashboardTextStrong
+            )
         }
     }
 }

--- a/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
+++ b/app/src/main/java/com/lcl/lclmeasurementtool/ui/HomeScreen.kt
@@ -48,6 +48,8 @@ fun HomeScreen(modifier: Modifier = Modifier, isOffline: Boolean, mainActivityVi
     val mlabRttResult = mainActivityViewModel.mlabRttResult.collectAsStateWithLifecycle()
     val mlabUploadResult = mainActivityViewModel.mlabUploadResult.collectAsStateWithLifecycle()
     val mlabDownloadResult = mainActivityViewModel.mlabDownloadResult.collectAsStateWithLifecycle()
+    val pingPacketLoss = mainActivityViewModel.pingPacketLoss.collectAsStateWithLifecycle()
+    val pingRttResult = mainActivityViewModel.pingRttResult.collectAsStateWithLifecycle()
     val signalStrength = mainActivityViewModel.signalStrengthResult.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
@@ -59,6 +61,8 @@ fun HomeScreen(modifier: Modifier = Modifier, isOffline: Boolean, mainActivityVi
         ) {
             SignalStrengthCard(modifier = modifier, signalStrengthResult = signalStrength.value)
             ConnectivityCard(
+                packetLoss = pingPacketLoss.value,
+                pingRtt = pingRttResult.value,
                 label = "MLab",
                 modifier = modifier,
                 rttValue = mlabRttResult.value,
@@ -150,6 +154,8 @@ private fun ConnectivityCard(
     rttValue: ConnectivityTestResult,
     uploadResult: ConnectivityTestResult,
     downloadResult: ConnectivityTestResult,
+    packetLoss: String = "-- %",
+    pingRtt: String = "-- ms",
 ) {
     Card(colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surfaceVariant),
         modifier = Modifier
@@ -196,7 +202,8 @@ private fun ConnectivityCard(
                     }
 
                     DataEntry(icon = Rounded.NetworkPing, text = "$formattedRtt ms")
-                    DataEntry(icon = Rounded.Cancel, text = "0 % loss")
+                    DataEntry(icon = Rounded.Cancel, text = packetLoss)
+                    DataEntry(icon = Rounded.NetworkPing, text = pingRtt)
                 }
 
             }


### PR DESCRIPTION
## Summary
- move Home connectivity dashboard UI updates into a dedicated PR
- keep PR #20 focused on ping implementation internals
- include dashboard styling and metric tile layout refinements

## Notes
- This PR is intentionally stacked on top of #20 (`nini-50-task-2-udp-scaffold`) so it only contains UI/dashboard changes.
- After #20 merges, this PR can be retargeted to `main` if needed.
- Custom Ping currently shows -- ms until PING_SERVER_ADDRESS points to a reachable endpoint (default is google.com:443, and the ping packet protocol requires a compatible server response).

## Testing
- ./gradlew --no-daemon :app:compileDevDebugKotlin
- ./gradlew --no-daemon :app:testDevDebugUnitTest --tests "com.lcl.lclmeasurementtool.features.ping.PingCodecTest"

## Screenshots
- Home (before run)
<img width="301" height="658" alt="Screenshot 2026-08-09 at 12 01 57 PM" src="https://github.com/user-attachments/assets/0273cb0d-1715-4cf8-a4a5-01f9448a3018" />


- Home (during run)
<img width="296" height="665" alt="Screenshot 2026-08-09 at 12 08 09 PM" src="https://github.com/user-attachments/assets/b396db54-2c19-4f65-a97d-c7068d37f3db" />


- Home (after run)
<img width="296" height="653" alt="Screenshot 2026-08-09 at 12 08 40 PM" src="https://github.com/user-attachments/assets/fd6af149-0989-4031-84cf-e8c9b8022845" />


- History (saved result)
<img width="317" height="680" alt="Screenshot 2026-08-09 at 12 09 37 PM" src="https://github.com/user-attachments/assets/e2b26fdf-4591-4eca-a3ea-e41743a12d6a" />
